### PR TITLE
[WIP] Fix Invalid Operation Error for Custom Single Control Unitary Gates in AerSimulator

### DIFF
--- a/qiskit/circuit/add_control.py
+++ b/qiskit/circuit/add_control.py
@@ -237,6 +237,8 @@ def control(
     else:
         ctrl_substr = ("{0}" * new_num_ctrl_qubits).format("c")
     new_name = f"{ctrl_substr}{base_name}"
+    if new_name == 'cu':
+        operation.params.append(0)
     cgate = controlledgate.ControlledGate(
         new_name,
         controlled_circ.num_qubits,


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add a release note file using reno if the change needs to be
  documented in the release notes.
⚠️ If your pull request fixes an open issue, please link to the issue.


- [ ] I have added the tests to cover my changes.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the CONTRIBUTING document.
-->

### Summary
The issue being addressed is detailed here: [Qiskit [Issue #12625](https://github.com/Qiskit/qiskit/issues/12625)]
This pull request addresses the issue with the add_control method for custom single control unitary gates when using the AerSimulator. Specifically, the issue arises when creating a controlled version of a UGate, which requires four parameters while the add_control method was only providing three. The fix involves adding a default value of gamma = 0 to the parameters of the CU gate when it is missing.

### Details and comments
The main change is in the control method where a check for the CU gate name is added. If the name matches, a default gamma = 0 is appended to the parameters. This ensures that the instructions for cu gate has 4 parameters

Example Code to Reproduce the issue
```
from qiskit import QuantumCircuit
from qiskit_aer import AerSimulator
from qiskit.circuit.add_control import add_control
from qiskit.circuit.library import UGate

qc = QuantumCircuit(3)
Sim = AerSimulator()
gate = UGate(-1.945632646294958, 1.5120405041931422, 2.4393357222229826)
control_gate = add_control(gate, label='test', num_ctrl_qubits=1, ctrl_state=1)
qc.append(control_gate, [1, 0])
qc.save_statevector()
result = Sim.run(qc).result().data(0)
```


